### PR TITLE
Add targetNetworkName check to the NodeBridge

### DIFF
--- a/inx/component.go
+++ b/inx/component.go
@@ -41,7 +41,9 @@ func provide(c *dig.Container) error {
 		return nodebridge.NewNodeBridge(CoreComponent.Daemon().ContextStopped(),
 			ParamsINX.Address,
 			ParamsINX.MaxConnectionAttempts,
-			CoreComponent.Logger())
+			CoreComponent.Logger(),
+			nodebridge.WithTargetNetworkName(ParamsINX.TargetNetworkName),
+		)
 	})
 }
 

--- a/inx/params.go
+++ b/inx/params.go
@@ -7,6 +7,7 @@ import (
 type ParametersINX struct {
 	Address               string `default:"localhost:9029" usage:"the INX address to which to connect to"`
 	MaxConnectionAttempts uint   `default:"30" usage:"the amount of times the connection to INX will be attempted before it fails (1 attempt per second)"`
+	TargetNetworkName     string `default:"" usage:"the network name on which the node should operate on (optional)"`
 }
 
 var ParamsINX = &ParametersINX{}


### PR DESCRIPTION
This PR adds an additional check for the correct targetNetworkName during connection initialization to the node.