### PR TITLE
Add node status context

### DIFF
--- a/pkg/nodebridge/milestones.go
+++ b/pkg/nodebridge/milestones.go
@@ -35,10 +35,12 @@ func milestoneFromINXMilestone(ms *inx.Milestone) (*Milestone, error) {
 }
 
 func (n *NodeBridge) LatestMilestone() (*Milestone, error) {
-	n.nodeStatusMutex.RLock()
-	defer n.nodeStatusMutex.RUnlock()
+	nodeStatus, err := n.NodeStatus()
+	if err != nil {
+		return nil, err
+	}
 
-	return milestoneFromINXMilestone(n.nodeStatus.GetLatestMilestone())
+	return milestoneFromINXMilestone(nodeStatus.GetLatestMilestone())
 }
 
 func (n *NodeBridge) LatestMilestoneIndex() uint32 {
@@ -51,10 +53,12 @@ func (n *NodeBridge) LatestMilestoneIndex() uint32 {
 }
 
 func (n *NodeBridge) ConfirmedMilestone() (*Milestone, error) {
-	n.nodeStatusMutex.RLock()
-	defer n.nodeStatusMutex.RUnlock()
+	nodeStatus, err := n.NodeStatus()
+	if err != nil {
+		return nil, err
+	}
 
-	return milestoneFromINXMilestone(n.nodeStatus.GetConfirmedMilestone())
+	return milestoneFromINXMilestone(nodeStatus.GetConfirmedMilestone())
 }
 
 func (n *NodeBridge) ConfirmedMilestoneIndex() uint32 {

--- a/pkg/nodebridge/node_bridge.go
+++ b/pkg/nodebridge/node_bridge.go
@@ -36,6 +36,7 @@ type NodeBridge struct {
 	NodeConfig         *inx.NodeConfiguration
 	nodeStatusMutex    sync.RWMutex
 	nodeStatus         *inx.NodeStatus
+	nodeStatusCtx      context.Context //nolint:containedctx
 	protocolParameters *iotago.ProtocolParameters
 }
 


### PR DESCRIPTION
This PR adds a context to the node status, so we can return an error if the stream to update the node status was closed.